### PR TITLE
Bump commons-lang3 from 3.11 to 3.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.11</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>com.jcraft</groupId>


### PR DESCRIPTION
### Description

In this pull request, the version of the Apache Commons Lang library dependency in the `pom.xml` file is being updated from `3.11` to `3.12.0`.

Changes:
- Update Apache Commons Lang library dependency version from `3.11` to `3.12.0` in the `pom.xml` file.